### PR TITLE
Fix issue with styleCustomisation parameter

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -199,7 +199,7 @@ export namespace Components {
   interface PskListFeedbacks {
     'alertRenderer'?: string;
     'messagesToDisplay'?: number;
-    'styleCustomisation'?: StyleCustomisation;
+    'styleCustomisation'?: StyleCustomisation | string;
     'timeAlive'?: number;
     'toastRenderer'?: string;
   }
@@ -335,7 +335,7 @@ export namespace Components {
   }
   interface PskUiAlert {
     'message': any;
-    'styleCustomisation': StyleCustomisation;
+    'styleCustomisation': StyleCustomisation | string;
     'timeAlive': any;
     'typeOfAlert': string;
   }
@@ -344,7 +344,7 @@ export namespace Components {
   }
   interface PskUiToast {
     'message': any;
-    'styleCustomisation': StyleCustomisation;
+    'styleCustomisation'?: StyleCustomisation | string;
     'timeMeasure': string;
     'timeSinceCreation': number;
   }
@@ -1072,7 +1072,7 @@ declare namespace LocalJSX {
     'alertRenderer'?: string;
     'messagesToDisplay'?: number;
     'onOpenFeedback'?: (event: CustomEvent<any>) => void;
-    'styleCustomisation'?: StyleCustomisation;
+    'styleCustomisation'?: StyleCustomisation | string;
     'timeAlive'?: number;
     'toastRenderer'?: string;
   }
@@ -1213,7 +1213,7 @@ declare namespace LocalJSX {
   interface PskUiAlert {
     'message'?: any;
     'onCloseFeedback'?: (event: CustomEvent<any>) => void;
-    'styleCustomisation'?: StyleCustomisation;
+    'styleCustomisation'?: StyleCustomisation | string;
     'timeAlive'?: any;
     'typeOfAlert'?: string;
   }
@@ -1223,7 +1223,7 @@ declare namespace LocalJSX {
   interface PskUiToast {
     'message'?: any;
     'onCloseFeedback'?: (event: CustomEvent<any>) => void;
-    'styleCustomisation'?: StyleCustomisation;
+    'styleCustomisation'?: StyleCustomisation | string;
     'timeMeasure'?: string;
     'timeSinceCreation'?: number;
   }

--- a/src/components/psk-list-feedbacks/psk-list-feedbacks.tsx
+++ b/src/components/psk-list-feedbacks/psk-list-feedbacks.tsx
@@ -1,4 +1,4 @@
-import { Component, State, Event, EventEmitter, Listen, h, Prop } from "@stencil/core";
+import { Component, State, Event, EventEmitter, Listen, h, Prop, Watch } from "@stencil/core";
 import { Message } from '../../interfaces/FeedbackMessage'
 import { StyleCustomisation } from '../../interfaces/StyleCustomisation'
 import Config from "./Config.js";
@@ -10,6 +10,8 @@ import CustomTheme from "../../decorators/CustomTheme";
     shadow: true
 })
 export class PskListFeebacks {
+    private _styleCustomisation: StyleCustomisation = {};
+
     @State() alertOpened: boolean = false;
     @State() _messagesQueue: Message[] = [];
     @State() _messagesContent: Message[] = [];
@@ -17,7 +19,7 @@ export class PskListFeebacks {
     @State() timer = 0;
     @State() opened: boolean = false;
     @State() typeOfAlert: Array<string> = [];
-   
+
     @CustomTheme()
     @TableOfContentProperty({
         description: `This property is a object based on StyleCustomisation interface `,
@@ -25,7 +27,15 @@ export class PskListFeebacks {
         propertyType: `StyleCustomisation type`,
         specialNote: `Even if you do not use all the parameters there will not be a problem with the default renderers.`,
     })
-    @Prop() styleCustomisation?: StyleCustomisation
+    @Prop() styleCustomisation?: StyleCustomisation | string = {}
+    @Watch('styleCustomisation')
+    styleCustomisationWatcher(newValue: StyleCustomisation | string) {
+        if (typeof newValue === 'string') {
+            this._styleCustomisation = JSON.parse(newValue);
+        } else {
+            this._styleCustomisation = newValue;
+        }
+    }
 
     @TableOfContentProperty({
         description: `This property is the auto closing timer in milliseconds for the alert.`,
@@ -97,6 +107,7 @@ export class PskListFeebacks {
     }
 
     componentWillLoad() {
+        this.styleCustomisationWatcher(this.styleCustomisation);
         this.openFeedbackHandler.emit((message, name, typeOfAlert) => {
             if (typeOfAlert) {
                 this.typeOfAlert.push(typeOfAlert)
@@ -170,7 +181,7 @@ export class PskListFeebacks {
                     message={message}
                     timeSinceCreation={this.timer}
                     timeMeasure={this.timeMeasure}
-                    styleCustomisation={this.styleCustomisation} />)
+                    styleCustomisation={this._styleCustomisation} />)
             }
             else {
                 _feedbackTag = this.alertRenderer ? this.alertRenderer : 'psk-ui-alert'
@@ -179,7 +190,7 @@ export class PskListFeebacks {
                         message={this._messagesContent[this._messagesContent.length - 1]}
                         typeOfAlert={this.typeOfAlert[key]}
                         timeAlive={this.timeAlive}
-                        styleCustomisation={this.styleCustomisation} />
+                        styleCustomisation={this._styleCustomisation} />
                 )
             }
         })

--- a/src/components/psk-ui-alert/psk-ui-alert.tsx
+++ b/src/components/psk-ui-alert/psk-ui-alert.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Prop, Event, EventEmitter, State } from '@stencil/core'
+import { Component, h, Prop, Event, EventEmitter, State, Watch } from '@stencil/core'
 import Config from "../psk-list-feedbacks/Config.js";
 
 import {StyleCustomisation} from '../../interfaces/StyleCustomisation';
@@ -10,6 +10,8 @@ import CustomTheme from '../../decorators/CustomTheme.js';
 })
 
 export class AlertComponent {
+    private _styleCustomisation: StyleCustomisation = {};
+
     @CustomTheme()
     @TableOfContentProperty({
         description: `This property is a string that indicates the type of alert that you want so send back to the user`,
@@ -38,9 +40,16 @@ export class AlertComponent {
         isMandatory: false,
         propertyType: `StyleCustomisation`,
     })
-    @Prop() styleCustomisation: StyleCustomisation
+    @Prop() styleCustomisation: StyleCustomisation | string = {}
+    @Watch('styleCustomisation')
+    styleCustomisationWatcher(newValue: StyleCustomisation | string) {
+        if (typeof newValue === 'string') {
+            this._styleCustomisation = JSON.parse(newValue);
+        } else {
+            this._styleCustomisation = newValue;
+        }
+    }
 
-    @State() alert: any = null;
     @State() isVisible: boolean = true;
     @Event({
         eventName: 'closeFeedback',
@@ -48,15 +57,23 @@ export class AlertComponent {
         cancelable: true,
         bubbles: true,
     }) closeFeedback: EventEmitter
+
+    alert: any = null;
+
     closeUIFeedback() {
         this.isVisible = false;
         setTimeout(() => {
             this.closeFeedback.emit(this.message)
         }, 1000);
     }
+
+    componentWillLoad() {
+        this.styleCustomisationWatcher(this.styleCustomisation);
+    }
+
     render() {
         this.alert = (
-            <div class={`alert ${this.typeOfAlert} alert-dismissible fade ${this.isVisible ? 'show' : 'hide'}`}  style={this.styleCustomisation.alert ? (this.styleCustomisation.alert.style ? this.styleCustomisation.alert.style : {} ) : {}} onClick={() => {
+            <div class={`alert ${this.typeOfAlert} alert-dismissible fade ${this.isVisible ? 'show' : 'hide'}`}  style={this._styleCustomisation.alert ? (this._styleCustomisation.alert.style ? this._styleCustomisation.alert.style : {} ) : {}} onClick={() => {
                 this.closeUIFeedback()
             }}>
                 <slot />

--- a/src/components/psk-ui-toast/psk-ui-toast.tsx
+++ b/src/components/psk-ui-toast/psk-ui-toast.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Prop, Event, EventEmitter, State } from '@stencil/core'
+import { Component, h, Prop, Event, EventEmitter, State, Watch } from '@stencil/core'
 import {StyleCustomisation} from '../../interfaces/StyleCustomisation'
 import { TableOfContentProperty } from '../../decorators/TableOfContentProperty';
 import { TableOfContentEvent } from '../../decorators/TableOfContentEvent';
@@ -10,6 +10,8 @@ import CustomTheme from '../../decorators/CustomTheme';
 })
 
 export class PskUiToast {
+    private _styleCustomisation: StyleCustomisation = {};
+
     @CustomTheme()
     @TableOfContentProperty({
         description: `This property is the message that will be rendered on the toast`,
@@ -38,7 +40,15 @@ export class PskUiToast {
         isMandatory: false,
         propertyType: `StyleCustomisation`,
     })
-    @Prop() styleCustomisation: StyleCustomisation
+    @Prop() styleCustomisation?: StyleCustomisation | string = {}
+    @Watch('styleCustomisation')
+    styleCustomisationWatcher(newValue: StyleCustomisation | string) {
+        if (typeof newValue === 'string') {
+            this._styleCustomisation = JSON.parse(newValue);
+        } else {
+            this._styleCustomisation = newValue;
+        }
+    }
 
     @State() toast: any = null;
 
@@ -53,11 +63,15 @@ export class PskUiToast {
         bubbles: true,
     }) closeFeedback: EventEmitter
 
+    componentWillLoad() {
+        this.styleCustomisationWatcher(this.styleCustomisation);
+    }
+
     render() {
         return (
             this.toast = (
-                <div class="toast fade out show" style={this.styleCustomisation.toast ? (this.styleCustomisation.toast.feedback ? (this.styleCustomisation.toast.feedback.style ? this.styleCustomisation.toast.feedback.style : {}) : {}) : {}}>
-                    <div class="toast-header" style={this.styleCustomisation.toast ?( this.styleCustomisation.toast.header ? (this.styleCustomisation.toast.header.style ? this.styleCustomisation.toast.header.style : {} ) : {}):{}}>
+                <div class="toast fade out show" style={this._styleCustomisation.toast ? (this._styleCustomisation.toast.feedback ? (this._styleCustomisation.toast.feedback.style ? this._styleCustomisation.toast.feedback.style : {}) : {}) : {}}>
+                    <div class="toast-header" style={this._styleCustomisation.toast ?( this._styleCustomisation.toast.header ? (this._styleCustomisation.toast.header.style ? this._styleCustomisation.toast.header.style : {} ) : {}):{}}>
                         <strong class="mr-auto">{this.message.name}</strong>
                         {(this.timeMeasure !== 'Right now') ? <small>{this.timeSinceCreation} {this.timeMeasure} </small> : <small>{this.timeMeasure} </small>}
                         <button
@@ -71,7 +85,7 @@ export class PskUiToast {
                             <span >&times;</span>
                         </button>
                     </div>
-                    <div class="toast-body" style={this.styleCustomisation.toast ?( this.styleCustomisation.toast.body ? (this.styleCustomisation.toast.body.style ? this.styleCustomisation.toast.body.style : {} ) : {}):{}}>
+                    <div class="toast-body" style={this._styleCustomisation.toast ?( this._styleCustomisation.toast.body ? (this._styleCustomisation.toast.body.style ? this._styleCustomisation.toast.body.style : {} ) : {}):{}}>
                         {this.message.content}
                     </div>
                 </div>

--- a/src/interfaces/StyleCustomisation.ts
+++ b/src/interfaces/StyleCustomisation.ts
@@ -1,19 +1,19 @@
 export interface StyleCustomisation{
-    toast: {
-        header: {
-            style: { [key: string]: string; },
-            title: string
+    toast?: {
+        header?: {
+            style?: { [key: string]: string; },
+            title?: string
         },
-        body:{
-            style: { [key: string]: string; },
-            content: string
+        body?:{
+            style?: { [key: string]: string; },
+            content?: string
         },
-        feedback: {
-            style: { [key: string]: string; }
+        feedback?: {
+            style?: { [key: string]: string; }
         }
     }
-    alert:{
-        style:{ [key: string]: string; },
-        content:string
+    alert?: {
+        style? :{ [key: string]: string; },
+        content?: string
     }
 }


### PR DESCRIPTION
Refactor the feedback components to allow style declarations to be
passed as strings in the `style-customisation` attribute.

Make the StyleCustomisation interface properties optional in order to
prevent passing the `toast` configuration to an alert component and
vice-versa.

Set a default empty object for the style-customisation attribute in order
to prevent `undefined` errors