### PR TITLE
Ensure cardinal can be extended without negative impact

### DIFF
--- a/src/controllers/base-controllers/index.js
+++ b/src/controllers/base-controllers/index.js
@@ -1,0 +1,2 @@
+export { default as ContainerController } from "./ContainerController";
+export { default as ModalController } from "./ModalController";

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -1,0 +1,4 @@
+export { default as AppConfigurationHelper } from "./AppConfigurationHelper";
+export { default as DefaultApplicationController } from "./DefaultApplicationController";
+export * from "./base-controllers";
+export { default as defaultApplicationConfig } from "./defaultApplicationConfig.json";

--- a/src/decorators/custom-theme/CustomTheme.new.ts
+++ b/src/decorators/custom-theme/CustomTheme.new.ts
@@ -1,14 +1,16 @@
 import { ComponentInterface, getElement } from "@stencil/core";
 import { applyStyles } from "../../utils/utilFunctions";
 
-const GLOBALS = {
+window.cardinal = window.cardinal || {};
+window.cardinal.customTheme = window.cardinal.customTheme || {
   THEME: undefined,
   IMPORTS: {},
   // DEPENDENCIES: {},
   EVENTS: {
-    GET_THEME: "getThemeConfig"
+    GET_THEME: "getThemeConfig",
   }
-}
+};
+const GLOBALS = window.cardinal.customTheme;
 
 type CustomThemeInterface = (
   target: ComponentInterface,

--- a/src/decorators/custom-theme/CustomTheme.old.ts
+++ b/src/decorators/custom-theme/CustomTheme.old.ts
@@ -5,10 +5,17 @@ declare type CustomThemeInterface = (
   methodName: string
 ) => void;
 
+window.cardinal = window.cardinal || {};
+window.cardinal.oldCustomTheme = window.cardinal.oldCustomTheme || {};
+
+const { oldCustomTheme } = window.cardinal;
+oldCustomTheme.dependencies =  oldCustomTheme.dependencies || {};
+oldCustomTheme.imports =  oldCustomTheme.imports || {};
+oldCustomTheme.appTheme =  oldCustomTheme.appTheme || null;
+
+const { dependencies, imports } = oldCustomTheme;
+
 const regex = /@import.*?["']([^"']+)["'].*?;/g
-let dependencies = {};
-let imports = {};
-let appTheme;
 
 function checkForInnerDependencies(referrer, styleStr) {
 
@@ -182,7 +189,7 @@ export default function CustomTheme(): CustomThemeInterface {
           }))
         };
 
-        if (!appTheme) {
+        if (!oldCustomTheme.appTheme) {
           return new Promise((resolve)=>{
             let event = new CustomEvent("getThemeConfig", {
               bubbles: true,
@@ -192,8 +199,8 @@ export default function CustomTheme(): CustomThemeInterface {
                 if (err) {
                   return console.log(err);
                 }
-                appTheme = theme;
-                injectThemeStyle(appTheme).then(()=>{
+                oldCustomTheme.appTheme = theme;
+                injectThemeStyle(oldCustomTheme.appTheme).then(()=>{
                   resolve();
                 });
               }
@@ -203,7 +210,7 @@ export default function CustomTheme(): CustomThemeInterface {
           });
         }
         else{
-          return injectThemeStyle(appTheme);
+          return injectThemeStyle(oldCustomTheme.appTheme);
         }
       }
     };

--- a/src/decorators/index.ts
+++ b/src/decorators/index.ts
@@ -1,0 +1,6 @@
+export * from "./declarations/declarations";
+export * from "./BindModel";
+export { default as ComponentInheritor } from "./ComponentInheritor";
+export { default as CustomTheme } from "./CustomTheme";
+export * from "./TableOfContentEvent";
+export * from "./TableOfContentProperty";

--- a/src/globals/index.ts
+++ b/src/globals/index.ts
@@ -1,5 +1,16 @@
 import { setMode } from '@stencil/core';
 
+declare global {
+  interface Window {
+    cardinal: {
+      oldCustomTheme?: any;
+      customTheme?: any;
+      controllers?: any;
+      pendingControllerRequests?: any;
+    };
+  }
+}
+
 export default () => setMode(element => {
   return (element as any).mode || element.getAttribute('mode') || 'default';
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,7 @@
-export * from './components';
-import '@stencil/router';
+export * from "./components";
+import "@stencil/router";
+
+export * from "./controllers";
+export * from "./decorators";
+export * from "./services";
+export * from "./utils";

--- a/src/services/ControllerRegistryService.js
+++ b/src/services/ControllerRegistryService.js
@@ -1,46 +1,48 @@
+window.cardinal = window.cardinal || {};
+window.cardinal.controllers = window.cardinal.controllers || {};
+window.cardinal.pendingControllerRequests =
+  window.cardinal.pendingControllerRequests || {};
+
+const { controllers, pendingControllerRequests } = window.cardinal;
+
 class ControllerRegistryService {
-    constructor() {
-        this.controllers = {};
-        this.pendingControllerRequests = {}
-    }
+  registerController(controllerName, controller) {
+    controllers[controllerName] = controller;
+    this._fullFillPreviousRequests(controllerName);
+  }
 
-    registerController(controllerName, controller) {
-        this.controllers[controllerName] = controller;
-        this._fullFillPreviousRequests(controllerName);
+  _fullFillPreviousRequests(controllerName) {
+    if (pendingControllerRequests[controllerName]) {
+      while (pendingControllerRequests[controllerName].length) {
+        let request = pendingControllerRequests[controllerName].pop();
+        request.resolve(controllers[controllerName]);
+      }
     }
+  }
 
-    _fullFillPreviousRequests(controllerName) {
-        if (this.pendingControllerRequests[controllerName]) {
-            while (this.pendingControllerRequests[controllerName].length) {
-                let request = this.pendingControllerRequests[controllerName].pop();
-                request.resolve(this.controllers[controllerName]);
-            }
+  getController(controllerName) {
+    let controllerPromise = new Promise((resolve, reject) => {
+      if (controllers[controllerName]) {
+        resolve(controllers[controllerName]);
+      } else {
+        let resourcePath = `scripts/controllers/${controllerName}.js`;
+        if (typeof window.basePath !== "undefined") {
+          let sep = "/";
+          if (window.basePath[window.basePath.length - 1] === sep) {
+            sep = "";
+          }
+          resourcePath = window.basePath + sep + resourcePath;
         }
-    }
+        import(resourcePath)
+          .then((module) => {
+            resolve(module.default || module);
+          })
+          .catch(reject);
+      }
+    });
 
-    getController(controllerName) {
-        let controllerPromise = new Promise((resolve, reject) => {
-
-            if (this.controllers[controllerName]) {
-                resolve(this.controllers[controllerName]);
-            } else {
-                let resourcePath = `scripts/controllers/${controllerName}.js`;
-                if(typeof window.basePath !== "undefined"){
-                    let sep = "/";
-                    if(window.basePath[window.basePath.length-1] ===sep){
-                        sep = "";
-                    }
-                    resourcePath = window.basePath+sep+resourcePath;
-                }
-                import (resourcePath)
-                .then((module) => {
-                    resolve(module.default || module);
-                }).catch(reject);
-            }
-        });
-
-        return controllerPromise;
-    }
+    return controllerPromise;
+  }
 }
 
-export default new ControllerRegistryService();
+export default ControllerRegistryService;

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,1 @@
+export { default as ControllerRegistryService } from "./ControllerRegistryService";

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,3 @@
+export * from "./constants";
+export * from "./highlightChapter";
+export * from "./utilFunctions";

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -16,6 +16,7 @@ export const config: CardinalConfig = {
       type: 'dist',
       esmLoaderPath: '../loader',
       copy: [
+        { src: 'controllers/defaultApplicationConfig.json', warn: true },
         { src: 'controllers/AppConfigurationHelper.js', dest: "../cardinal/controllers/AppConfigurationHelper.js", warn: true },
         { src: 'controllers/base-controllers', dest: "../cardinal/controllers/base-controllers", warn: true },
         { src: 'events/*.js', dest: "../cardinal/events", warn: true },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
     "allowUnreachableCode": false,
-    "declaration": false,
+    "declaration": true,
     "experimentalDecorators": true,
     "lib": [
       "dom",


### PR DESCRIPTION
Changes done in this fork:
- ensure global caches wherever applicable (CustomTheme new and old, ControllerRegistryService). Their caches have been stored in the global window object in order to be publicly accessible by their equivalents from other libraries that extend Cardinal. The JS namespace pattern was used here, by creating a cardinal property on window, which will contain all the cardinal global information.

```
declare global {
  interface Window {
    cardinal: {
      oldCustomTheme?: any;
      customTheme?: any;
      controllers?: any;
      pendingControllerRequests?: any;
    };
  }
}
```

- export controllers, decorators, services and utils in cardinal's index.ts file, in order to be used more easily in custom libraries. This would have been easier to do if path alias could be safely used (e.g. `import { CustomTheme } from "cardinal/decorators"; `). When stencil sees path aliases, the build process will behave in the following way:
1. if path alias is used instead of relative path import to the following
2. resolve path alias to determine absolute file path
3. traverse parent directory until a parent package.json is found. if found then proceed to next step
4. check if package.json contains a collection entry (cardianal has this entry, required by stencil)
5. import all the collection inside the current project (this step will mean that the library extending cardinal will contain all of cardinal's components). There is no way to disable this because the behavior is "hardcoded" in the compiler logic.

Current cardinal is used inside project: [Axiologic/ConversationalWebComponent](https://github.com/Axiologic/ConversationalWebComponent)

ToDos:
1. Check new CustomTheme implementation for further cache related changes
2. Create a Guide on how to create a library extending cardinal.
